### PR TITLE
Gap between timeline children

### DIFF
--- a/lib/src/timeline_painter.dart
+++ b/lib/src/timeline_painter.dart
@@ -93,7 +93,7 @@ class _TimelinePainterCenter extends _TimelinePainter {
         configuration.size?.center(Offset(0.0, offset.dy - iconSize / 2 - 2 * TimelineBoxDecoration.LINE_GAP));
     final Offset? bottomLineStart =
         configuration.size?.center(Offset(0.0, offset.dy + iconSize / 2 + 2 * TimelineBoxDecoration.LINE_GAP));
-    final Offset? offsetBottom = configuration.size?.bottomCenter(Offset(0.0, offset.dy * 2));
+    final Offset? offsetBottom = configuration.size?.bottomCenter(Offset(0.0, offset.dy * 2 + properties.gap));
     if (!isFirst && offsetTop != null && topLineEnd != null) canvas.drawLine(offsetTop, topLineEnd, linePaint);
     if (!isLast && bottomLineStart != null && offsetBottom != null)
       canvas.drawLine(bottomLineStart, offsetBottom, linePaint);
@@ -128,7 +128,7 @@ class _TimelinePainterLeft extends _TimelinePainter {
     final Offset? top = configuration.size?.topLeft(Offset(leftOffset.dx, 0.0));
     final Offset? centerTop = configuration.size?.centerLeft(Offset(leftOffset.dx, leftOffset.dy - iconMargin));
     final Offset? centerBottom = configuration.size?.centerLeft(Offset(leftOffset.dx, leftOffset.dy + iconMargin));
-    final Offset? end = configuration.size?.bottomLeft(Offset(leftOffset.dx, leftOffset.dy * 2));
+    final Offset? end = configuration.size?.bottomLeft(Offset(leftOffset.dx, leftOffset.dy * 2 + properties.gap));
     if (!isFirst && top != null && centerTop != null) canvas.drawLine(top, centerTop, linePaint);
     if (!isLast && centerBottom != null && end != null) canvas.drawLine(centerBottom, end, linePaint);
 
@@ -162,7 +162,7 @@ class _TimelinePainterRight extends _TimelinePainter {
     final Offset? top = configuration.size?.topRight(Offset(rightOffset.dx, 0.0));
     final Offset? centerTop = configuration.size?.centerRight(Offset(rightOffset.dx, rightOffset.dy - iconMargin));
     final Offset? centerBottom = configuration.size?.centerRight(Offset(rightOffset.dx, rightOffset.dy + iconMargin));
-    final Offset? end = configuration.size?.bottomRight(Offset(rightOffset.dx, rightOffset.dy * 2));
+    final Offset? end = configuration.size?.bottomRight(Offset(rightOffset.dx, rightOffset.dy * 2 + properties.gap));
     if (!isFirst && top != null && centerTop != null) canvas.drawLine(top, centerTop, linePaint);
     if (!isLast && centerBottom != null && end != null) canvas.drawLine(centerBottom, end, linePaint);
 

--- a/lib/timeline.dart
+++ b/lib/timeline.dart
@@ -42,6 +42,7 @@ class Timeline extends StatelessWidget {
       Color? lineColor,
       double? lineWidth,
       double? iconSize,
+      double? gap,
       this.controller,
       this.position = TimelinePosition.Center,
       this.physics,
@@ -50,7 +51,7 @@ class Timeline extends StatelessWidget {
       this.reverse = false})
       : itemCount = children.length,
         properties = TimelineProperties(
-            lineColor: lineColor, lineWidth: lineWidth, iconSize: iconSize),
+            lineColor: lineColor, lineWidth: lineWidth, iconSize: iconSize, gap: gap),
         itemBuilder = ((BuildContext context, int i) => children[i]);
 
   /// Creates a scrollable timeline of widgets that are created on demand.
@@ -63,13 +64,14 @@ class Timeline extends StatelessWidget {
       Color? lineColor,
       double? lineWidth,
       double? iconSize,
+      double? gap,
       this.position = TimelinePosition.Center,
       this.physics,
       this.shrinkWrap = false,
       this.primary = false,
       this.reverse = false})
       : properties = TimelineProperties(
-            lineColor: lineColor, lineWidth: lineWidth, iconSize: iconSize);
+            lineColor: lineColor, lineWidth: lineWidth, iconSize: iconSize, gap: gap);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/timeline.dart
+++ b/lib/timeline.dart
@@ -14,11 +14,13 @@ class TimelineProperties {
   final Color lineColor;
   final double lineWidth;
   final double iconSize;
+  final double gap;
 
-  const TimelineProperties({Color? lineColor, double? lineWidth, double? iconSize})
+  const TimelineProperties({Color? lineColor, double? lineWidth, double? iconSize, double? gap})
       : lineColor = lineColor ?? const Color(0xFF333333),
         lineWidth = lineWidth ?? 2.5,
-        iconSize = iconSize ?? TimelineBoxDecoration.DEFAULT_ICON_SIZE;
+        iconSize = iconSize ?? TimelineBoxDecoration.DEFAULT_ICON_SIZE
+        gap = gap ?? 0.0;
 }
 
 class Timeline extends StatelessWidget {
@@ -88,7 +90,7 @@ class Timeline extends StatelessWidget {
           return Material(
             child: InkWell(
               onTap: model.onTap as void Function()?,
-              child: child(properties, model),
+              child: Container(child: child(properties, model), margin: EdgeInsets.only(bottom: properties.gap)),
             ),
           );
         });

--- a/lib/timeline.dart
+++ b/lib/timeline.dart
@@ -19,7 +19,7 @@ class TimelineProperties {
   const TimelineProperties({Color? lineColor, double? lineWidth, double? iconSize, double? gap})
       : lineColor = lineColor ?? const Color(0xFF333333),
         lineWidth = lineWidth ?? 2.5,
-        iconSize = iconSize ?? TimelineBoxDecoration.DEFAULT_ICON_SIZE
+        iconSize = iconSize ?? TimelineBoxDecoration.DEFAULT_ICON_SIZE,
         gap = gap ?? 0.0;
 }
 


### PR DESCRIPTION
The **gap** option is added to properties so you can have space between the timeline children without messing up the center position of the icon.